### PR TITLE
chore: upgrade to go 1.22

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -81,7 +81,7 @@ func (cerbereConfig *Cerbere) ServeHTTP(rw http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	body, err := ioutil.ReadAll(authResponse.Body)
+	body, err := io.ReadAll(authResponse.Body)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ZeroGachis/traefik-auth-middleware
 
-go 1.15
+go 1.22


### PR DESCRIPTION
In order to prepare upgrade to Traefik V3 